### PR TITLE
dispatch hangman events on another subscriber services that Symfony defaults one

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,6 +15,10 @@ services:
     #             #name : !php/const App\Kernel::HANGMAN_LOADER_TAG
     #             foo  : bar
     # default configuration only applies for services in *this* file
+    _instanceof:
+        App\Game\EventDispatcher\EventSubscriberInterface:
+            tags:
+                name: game.event_subscriber
     _defaults:
         autowire: true
         autoconfigure: true
@@ -51,8 +55,8 @@ services:
         $defaultCredits: '%hangman.game.default_credits%'
 
     # Use an other dispatcher than the one used by kernel
-    # TODO implement our tag & compilerPass because our Listener are autoTagged & added in Symfony default dispatcher
-    #hangman.game.dispatcher:
-    #    class: Symfony\Component\EventDispatcher\EventDispatcher
-    #App\Game\Runner:
-    #    $dispatcher: '@hangman.game.dispatcher'
+    # @see Kernel::addGameEventSubscribers() with game.event_subscriber
+    hangman.game.dispatcher:
+        class: Symfony\Component\EventDispatcher\EventDispatcher
+    App\Game\Runner:
+        $dispatcher: '@hangman.game.dispatcher'

--- a/src/Extension/HangmanExtensionConfiguration.php
+++ b/src/Extension/HangmanExtensionConfiguration.php
@@ -1,0 +1,107 @@
+<?php
+
+
+namespace App\Extension;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+/**
+ * Class HangmanExtension
+ *
+ * @package App\Extension
+ */
+class HangmanExtensionConfiguration implements ExtensionInterface, ConfigurationInterface
+{
+
+    /**
+     * Loads a specific configuration.
+     *
+     * @param array            $configs
+     * @param ContainerBuilder $container
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $processor = new Processor();
+        // check config validity & merge multiple configs (@see Kernel::configureContainer for overriding rules)
+        $config  = $processor->processConfiguration($this, $configs);
+
+        $container->setParameter('hangman.game.dictionaries', $config['game']['dictionaries']);
+        $container->setParameter('hangman.game.default_credits', $config['game']['default_credits']);
+        $container->setParameter('hangman.game.required_age', $config['game']['required_age']);
+    }
+
+    /**
+     * Returns the namespace to be used for this extension (XML namespace).
+     *
+     * @return string The XML namespace
+     */
+    public function getNamespace()
+    {
+        return '';
+    }
+
+    /**
+     * Returns the base path for the XSD files.
+     *
+     * @return string|false
+     */
+    public function getXsdValidationBasePath()
+    {
+        return false;
+    }
+
+    /**
+     * Returns the recommended alias to use in XML.
+     *
+     * This alias is also the mandatory prefix to use when using YAML.
+     *
+     * @return string The alias
+     */
+    public function getAlias()
+    {
+        return 'hangman';
+    }
+
+    /**
+     * Generates the configuration tree builder.
+     * - validate
+     * - parse
+     * - merge
+     *
+     * @return TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $tree = new TreeBuilder($this->getAlias());
+        $game = $tree->getRootNode()->children()->arrayNode('game');
+        $game->children()
+            ->arrayNode('dictionaries')
+                ->isRequired()
+                ->prototype('scalar')
+                    ->isRequired()
+                    ->validate()
+                        ->ifTrue(function ($value) { return !is_readable($value); })
+                        ->thenInvalid('file must exist')
+                    ->end() // end validate
+                ->end() // end prototype
+            ->end() // arrayNode dictionaries
+            ->integerNode('default_credits')
+                ->defaultValue(10)
+                ->min(5)
+                ->max(15)
+            ->end() // integerNode
+                ->integerNode('required_age')
+                ->defaultValue(10)
+                ->min(16)
+                ->max(23)
+            ->end() // integerNode
+        ->end() // end game
+        ;
+
+        return $tree;
+    }
+}

--- a/src/Game/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Game/EventDispatcher/EventSubscriberInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace App\Game\EventDispatcher;
+
+use \Symfony\Component\EventDispatcher\EventSubscriberInterface as SymfonyEventSubscriberInterface;
+/**
+ * interface EventSubscriberInterface
+ *
+ * @package App\Game\EventDispatcher
+ */
+interface EventSubscriberInterface extends SymfonyEventSubscriberInterface
+{
+
+}

--- a/src/Game/Listener/GameLogListener.php
+++ b/src/Game/Listener/GameLogListener.php
@@ -7,7 +7,7 @@ use App\Game\Event\AbstractGameEvent;
 use App\Game\Event\GameEndEvent;
 use App\Game\Event\GameStartEvent;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use App\Game\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Class GameLogListener

--- a/src/Game/Listener/GamePlayerCreditsListener.php
+++ b/src/Game/Listener/GamePlayerCreditsListener.php
@@ -8,7 +8,7 @@ use App\Game\Event\AbstractGameEvent;
 use App\Game\Event\GameEndEvent;
 use App\Game\Event\GameStartEvent;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use App\Game\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -2,21 +2,18 @@
 
 namespace App;
 
+use App\Extension\HangmanExtensionConfiguration;
 use App\Game\WordList;
 use App\Security\Voter\LegalAgeVoter;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
-class Kernel extends BaseKernel implements CompilerPassInterface, ExtensionInterface, ConfigurationInterface
+class Kernel extends BaseKernel implements CompilerPassInterface
 {
     use MicroKernelTrait;
 
@@ -145,95 +142,9 @@ class Kernel extends BaseKernel implements CompilerPassInterface, ExtensionInter
             ->registerForAutoconfiguration(Game\Loader\LoaderInterface::class)
             ->addTag(self::HANGMAN_LOADER_TAG, ['foo' => 'bar']);
         /*
-         * auto register as extension
+         * register extension for loading hangman: config tree
+         * DO NOT AUTO REGISTER BECAUSE self::process() is launched twice ???
          */
-        $container->registerExtension($this);
-    }
-
-    /**
-     * Loads a specific configuration.
-     *
-     * @param array            $configs
-     * @param ContainerBuilder $container
-     */
-    public function load(array $configs, ContainerBuilder $container)
-    {
-        $processor = new Processor();
-        $config  = $processor->processConfiguration($this, $configs);
-
-        $container->setParameter('hangman.game.dictionaries', $config['game']['dictionaries']);
-        $container->setParameter('hangman.game.default_credits', $config['game']['default_credits']);
-        $container->setParameter('hangman.game.required_age', $config['game']['required_age']);
-    }
-
-    /**
-     * Returns the namespace to be used for this extension (XML namespace).
-     *
-     * @return string The XML namespace
-     */
-    public function getNamespace()
-    {
-        return '';
-    }
-
-    /**
-     * Returns the base path for the XSD files.
-     *
-     * @return string|false
-     */
-    public function getXsdValidationBasePath()
-    {
-        return false;
-    }
-
-    /**
-     * Returns the recommended alias to use in XML.
-     *
-     * This alias is also the mandatory prefix to use when using YAML.
-     *
-     * @return string The alias
-     */
-    public function getAlias()
-    {
-        return 'hangman';
-    }
-
-    /**
-     * Generates the configuration tree builder.
-     * - validate
-     * - parse
-     * - merge
-     *
-     * @return TreeBuilder The tree builder
-     */
-    public function getConfigTreeBuilder()
-    {
-        $tree = new TreeBuilder($this->getAlias());
-        $game = $tree->getRootNode()->children()->arrayNode('game');
-        $game->children()
-            ->arrayNode('dictionaries')
-                ->isRequired()
-                ->prototype('scalar')
-                    ->isRequired()
-                    ->validate()
-                        ->ifTrue(function ($value) { return !\is_readable($value); })
-                        ->thenInvalid('file must exist')
-                    ->end() // end validate
-                ->end() // end prototype
-            ->end() // arrayNode dictionaries
-            ->integerNode('default_credits')
-                ->defaultValue(10)
-                ->min(5)
-                ->max(15)
-            ->end() // integerNode
-            ->integerNode('required_age')
-                ->defaultValue(10)
-                ->min(16)
-                ->max(23)
-            ->end() // integerNode
-        ->end() // end game
-        ;
-
-        return $tree;
+        $container->registerExtension(new HangmanExtensionConfiguration());
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -5,7 +5,9 @@ namespace App;
 use App\Extension\HangmanExtensionConfiguration;
 use App\Game\WordList;
 use App\Security\Voter\LegalAgeVoter;
+use Exception;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Exception\LoaderLoadException;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -89,6 +91,12 @@ class Kernel extends BaseKernel implements CompilerPassInterface
         }
     }
 
+    /**
+     * @param ContainerBuilder $container
+     * @param LoaderInterface  $loader
+     *
+     * @throws Exception
+     */
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
     {
         $container->setParameter('container.autowiring.strict_mode', true);
@@ -106,6 +114,11 @@ class Kernel extends BaseKernel implements CompilerPassInterface
         }
     }
 
+    /**
+     * @param RouteCollectionBuilder $routes
+     *
+     * @throws LoaderLoadException
+     */
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
         $confDir = $this->getProjectDir().'/config';


### PR DESCRIPTION
Latest Homework from sf4c3 with Julien Pauli.

@Julien

Peux tu valider cette PR STP, notamment le commit [1c44bcb](https://github.com/syjust/sf4c3/commit/1c44bcb7a5131b9038803777b8a2290ffc8e3073) en relation avec l'exercice visant à ne pas utiliser le service `event_dispatcher` par défaut de SF ?

comme tu peux le voir dans le commit [3e4334a](https://github.com/syjust/sf4c3/commit/3e4334a213dd0ef7f807110d70d29cdcb7de5b65), j'ai dû réimplémenter `ExtentionInterface` et `ConfigurationInterface` à l'extérieur du Kernel car sinon la méthode `Kernel::process` était lancée 2 fois (et du coup j'était débité de 2 crédits à chaque partie et avait 2 log dans game.log - il devait également y avoir 2 fois le dictionnaire chargé dans `WordList`, mais ça on ne pouvait pas le voir à l'usage ;) )...

Penses-tu que c'est un bug ? Sinon, comment cela s'explique-t-il ?

En tout cas, merci pour cette formation très enrichissante et au plaisir de te recroiser :)